### PR TITLE
Sprint11 188 mega menu text wrap on expand collapse

### DIFF
--- a/src/app/tl-header/tl-header.component.scss
+++ b/src/app/tl-header/tl-header.component.scss
@@ -403,6 +403,23 @@
     left: 0;
     z-index: 1100;
     transition: width 0.5s ease-in-out, opacity 0.5s ease-in-out;
+    .flex-fill.align-self-stretch {
+      div  {
+        wvr-nav-li > li.nav-item {
+          a {
+            white-space: nowrap;
+          }
+          .mobile-display tl-mega-menu-section-element,
+            .mobile-display tl-mega-menu-section {
+              white-space: nowrap;
+            }
+          tl-mega-menu > wvr-dropdown-element > .wvr-dropdown .dropdown wvr-button-element {
+            white-space: nowrap;
+          }
+        }
+      }
+    }
+
   }
 
 }

--- a/src/app/tl-header/tl-header.component.scss
+++ b/src/app/tl-header/tl-header.component.scss
@@ -403,8 +403,7 @@
     left: 0;
     z-index: 1100;
     transition: width 0.5s ease-in-out, opacity 0.5s ease-in-out;
-    div {
-      div {
+    div.mobile-menu-content {
         wvr-nav-li > li.nav-item {
           a {
             white-space: nowrap;
@@ -417,7 +416,6 @@
             white-space: nowrap;
           }
         }
-      }
     }
   }
 

--- a/src/app/tl-header/tl-header.component.scss
+++ b/src/app/tl-header/tl-header.component.scss
@@ -421,23 +421,4 @@
     }
   }
 
-  // nav.mobile-menu {
-  //   div {
-  //     div {
-  //       wvr-nav-li > li.nav-item {
-  //         a {
-  //           white-space: nowrap;
-  //         }
-  //         .mobile-display tl-mega-menu-section-element,
-  //           .mobile-display tl-mega-menu-section {
-  //             white-space: nowrap;
-  //           }
-  //         tl-mega-menu > wvr-dropdown-element > .wvr-dropdown .dropdown wvr-button-element {
-  //           white-space: nowrap;
-  //         }
-  //       }
-  //     }
-  //   }
-  // }
-
 }

--- a/src/app/tl-header/tl-header.component.scss
+++ b/src/app/tl-header/tl-header.component.scss
@@ -403,8 +403,8 @@
     left: 0;
     z-index: 1100;
     transition: width 0.5s ease-in-out, opacity 0.5s ease-in-out;
-    .flex-fill.align-self-stretch {
-      div  {
+    div {
+      div {
         wvr-nav-li > li.nav-item {
           a {
             white-space: nowrap;
@@ -419,7 +419,25 @@
         }
       }
     }
-
   }
+
+  // nav.mobile-menu {
+  //   div {
+  //     div {
+  //       wvr-nav-li > li.nav-item {
+  //         a {
+  //           white-space: nowrap;
+  //         }
+  //         .mobile-display tl-mega-menu-section-element,
+  //           .mobile-display tl-mega-menu-section {
+  //             white-space: nowrap;
+  //           }
+  //         tl-mega-menu > wvr-dropdown-element > .wvr-dropdown .dropdown wvr-button-element {
+  //           white-space: nowrap;
+  //         }
+  //       }
+  //     }
+  //   }
+  // }
 
 }

--- a/src/app/tl-mega-menu/tl-mega-menu.component.spec.ts
+++ b/src/app/tl-mega-menu/tl-mega-menu.component.spec.ts
@@ -126,7 +126,7 @@ describe('MegaMenuComponent', () => {
     expect(component.menuXOffset)
       .toBe(0);
 
-    tick(1000);
+    tick(5000);
 
     expect(component.menuXOffset)
         .toBeGreaterThan(0);

--- a/src/app/tl-mega-menu/tl-mega-menu.component.spec.ts
+++ b/src/app/tl-mega-menu/tl-mega-menu.component.spec.ts
@@ -126,7 +126,7 @@ describe('MegaMenuComponent', () => {
     expect(component.menuXOffset)
       .toBe(0);
 
-    tick(5000);
+    tick(10000);
 
     expect(component.menuXOffset)
         .toBeGreaterThan(0);


### PR DESCRIPTION
Resolves #188 The text-wrap property of the mega menu causes an undesirable flicker when expanding collapsing.