### PR TITLE
Issue 363: Weaver Components should use an alternate mechanism to display: none when components are ready.

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -56,7 +56,16 @@ export class TamuLibModule {
       });
 
     wvrTimeout(() => {
-      document.querySelector('body').style.display = 'block';
+      const elements = document.querySelectorAll('.wvr-components-display:not(body)');
+      elements.forEach(function(element) {
+        element.classList.remove('wvr-components-display');
+      });
+
+      const bodyElem = document.querySelector('body');
+      if (bodyElem) {
+        bodyElem.classList.remove('wvr-components-display');
+        bodyElem.classList.remove('wvr-hidden');
+      }
     });
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
   </style>
 </head>
 
-<body style="display: none;">
+<body class="wvr-components-display">
   <tl-header page-title="TL Header">
     <wvre-nav-li href="find-my-librarian">
       <wvre-text value="Find My Librarian"></wvre-text>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -9,6 +9,7 @@
   @import '~@wvr/elements/styles/overrides';
 }
 
+.wvr-components-display,
 .wvr-hidden {
   display: none !important;
 }


### PR DESCRIPTION
On startup, weaver will remove all `wvr-components-display` classes.
The body element is reserved for last to ensure that the body doesn't become visible while other elements are being updated.

relates TAMULib/weaver-components/issues/363