### PR TITLE
Issue 337: TAMU Header should support the suppression of the top navigation links, both complete suppression and discriminate.

### DIFF
--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.html
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.html
@@ -40,12 +40,13 @@
 </wvr-header-component>
 
 <ng-template #topNavContent>
-  <wvr-nav-li-component>
+  <wvr-nav-li-component *ngIf="showTopNav('hours')">
     <a href="https://library.tamu.edu/about/hours.html">
       <wvr-text-component value="Hours"></wvr-text-component>
     </a>
   </wvr-nav-li-component>
-  <wvr-nav-li-component>
+
+  <wvr-nav-li-component *ngIf="showTopNav('libraries')">
     <wvr-dropdown-component class="libraries"
       [btnType]="'link'"
       [btnHref]="'https://library.tamu.edu/about/index.html'"
@@ -123,7 +124,8 @@
       </template>
     </wvr-dropdown-component>
   </wvr-nav-li-component>
-  <wvr-nav-li-component>
+
+  <wvr-nav-li-component *ngIf="showTopNav('information for')">
     <wvr-dropdown-component class="information-for"
       [btnType]="'link'"
       [btnHref]="'https://library.tamu.edu'"
@@ -173,13 +175,14 @@
       </template>
     </wvr-dropdown-component>
   </wvr-nav-li-component>
-  <wvr-nav-li-component>
+
+  <wvr-nav-li-component *ngIf="showTopNav('mylibrary')">
     <a href="https://library.tamu.edu/mylibrary/">
       <wvr-text-component value="MyLibrary"></wvr-text-component>
     </a>
   </wvr-nav-li-component>
 
-  <wvr-nav-li-component>
+  <wvr-nav-li-component *ngIf="showTopNav('help')">
     <wvr-dropdown-component class="help"
       [btnType]="'link'"
       [btnHref]="'http://askus.library.tamu.edu/'"
@@ -235,7 +238,6 @@
       </template>
     </wvr-dropdown-component>
   </wvr-nav-li-component>
-
 </ng-template>
 
 <ng-template #bottomNavContent>

--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.ts
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.ts
@@ -47,6 +47,7 @@ export class TlHeaderComponent extends TamuAbstractBaseComponent {
   /** This boolean attribute is used to supress display of "Give to the Libraries" button. */
   @Input() suppressCallToAction: 'true' | 'false' = 'false';
 
+  /** This defines an array containing each top navigation to be suppressed or contains 'all' to suppress all top navigation. */
   suppressTopNavList: Array<string> = [];
 
   mobileMenuClosed = true;
@@ -56,10 +57,24 @@ export class TlHeaderComponent extends TamuAbstractBaseComponent {
     super(injector);
   }
 
+  /**
+   * Toggles Mobile Menu from open to closed.
+   */
   toggleMobileMenu(): void {
     this.mobileMenuClosed = !this.mobileMenuClosed;
   }
 
+  /**
+   * Designates top navigation to suppress.
+   *
+   * @param {string} value
+   *   - A CSV string of supported top navigation names.
+   *   - May specify 'all' to designate suppression of all top navigation.
+   *   - Each CSV will be trimmed.
+   *   - Each CSV will be treated in a case insensitive manner.
+   *
+   * @returns {void}
+   */
   @Input() set suppressTopNav(value: string) {
     this.suppressTopNavList.length = 0;
 
@@ -75,6 +90,18 @@ export class TlHeaderComponent extends TamuAbstractBaseComponent {
     }
   }
 
+  /**
+   * Method for checking whether or not a given top navigation is to be suppressed.
+   *
+   * @param {string} value
+   *   - The name of the top navigation.
+   *   - This will be trimmed.
+   *   - This is treated in a case insensitive manner.
+   *
+   * @returns {boolean}
+   *   - TRUE when the top navigation is not to be suppressed.
+   *   - FALSE when the top navigation is to be suppressed.
+   */
   showTopNav(value: string): boolean {
     return this.suppressTopNavList.indexOf('all') == -1
       && this.suppressTopNavList.indexOf(value.trim().toLowerCase()) == -1;

--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.ts
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.ts
@@ -47,6 +47,8 @@ export class TlHeaderComponent extends TamuAbstractBaseComponent {
   /** This boolean attribute is used to supress display of "Give to the Libraries" button. */
   @Input() suppressCallToAction: 'true' | 'false' = 'false';
 
+  suppressTopNavList: Array<string> = [];
+
   mobileMenuClosed = true;
 
   // tslint:disable-next-line:unnecessary-constructor
@@ -56,6 +58,26 @@ export class TlHeaderComponent extends TamuAbstractBaseComponent {
 
   toggleMobileMenu(): void {
     this.mobileMenuClosed = !this.mobileMenuClosed;
+  }
+
+  @Input() set suppressTopNav(value: string) {
+    this.suppressTopNavList.length = 0;
+
+    if (value.trim().toLowerCase() == 'all') {
+      this.suppressTopNavList.push('all');
+    }
+    else {
+      let values = value.split(',');
+
+      for (let key in values) {
+        this.suppressTopNavList.push(values[key].trim().toLowerCase());
+      }
+    }
+  }
+
+  showTopNav(value: string): boolean {
+    return this.suppressTopNavList.indexOf('all') == -1
+      && this.suppressTopNavList.indexOf(value.trim().toLowerCase()) == -1;
   }
 
 }

--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.ud-examples.html
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.ud-examples.html
@@ -6,3 +6,12 @@
     <tl-header page-title="TAMU Libraries"></tl-header>
   </snippet>
 </example>
+
+<example name="TL Header with Suppressed Top Nav">
+  <desciption>
+    The basic <code>tl-header</code> component with "Help" and "Information For" suppressed.
+  </desciption>
+  <snippet>
+    <tl-header page-title="TAMU Libraries" suppress-top-nav="help, information for"></tl-header>
+  </snippet>
+</example>


### PR DESCRIPTION
Utilize ngIf to conditionally suppress the top nav.
This avoids making any decisions on whether or not ngIf should be used for performance and memory reasons.

Implement a simple array to determine whether or not a given named element is to be suppressed.
The word 'all' is reserved for suppressing all navigation links.

The naming system is not explicitly provided so I opted to lowercase and trim the title text.
This is done because the user is most likely to know the title text.
This is only a noticeable problem for `information for`.
Other options are to always strip whitespace or to replace all inner whitespace with a '-', such as `information-for`.

resolves #337 