### PR TITLE
Issue 336: Tamu Components should support the TL Dropdown within the TL Header Bottom Nav, with mobile support.

### DIFF
--- a/projects/tl-elements/src/lib/core/tl-core.module.ts
+++ b/projects/tl-elements/src/lib/core/tl-core.module.ts
@@ -4,6 +4,8 @@ import { TlAlertComponent } from '../tl-alert/tl-alert.component';
 import { TlButtonComponent } from '../tl-button/tl-button.component';
 import { TlCardComponent } from '../tl-card/tl-card.component';
 import { TlDropDownComponent } from '../tl-dropdown/tl-dropdown.component';
+import { TlDropDownMenuSectionComponent } from '../tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component';
+import { TlDropDownMenuComponent } from '../tl-dropdown-menu/tl-dropdown-menu.component';
 import { TlFooterComponent } from '../tl-footer/tl-footer.component';
 import { TlHeaderComponent } from '../tl-header/tl-header.component';
 import { TlIconComponent } from '../tl-icon/tl-icon.component';
@@ -33,13 +35,15 @@ export const TL_ELEMENTS: Array<WvrElementDesc> = [
   { component: TlButtonComponent, selector: 'tl-button', lazy: true },
   { component: TlCardComponent, selector: 'tl-card', lazy: true },
   { component: TlDropDownComponent, selector: 'tl-dropdown', lazy: true },
+  { component: TlDropDownMenuSectionComponent, selector: 'tl-dropdown-menu-section', lazy: true },
+  { component: TlDropDownMenuComponent, selector: 'tl-dropdown-menu', lazy: true },
   { component: TlFooterComponent, selector: 'tl-footer', lazy: true },
   { component: TlHeaderComponent, selector: 'tl-header', lazy: true },
   { component: TlIconComponent, selector: 'tl-icon', lazy: true },
   { component: TlItWorksComponent, selector: 'tl-it-works', lazy: true },
   { component: TlMegaMenuComponent, selector: 'tl-mega-menu', lazy: true },
-  { component: TlModalComponent, selector: 'tl-modal', lazy: true },
   { component: TlMegaMenuSectionComponent, selector: 'tl-mega-menu-section', lazy: true },
+  { component: TlModalComponent, selector: 'tl-modal', lazy: true },
   { component: TlNavListComponent, selector: 'tl-nav-list', lazy: true },
   { component: TlTabsComponent, selector: 'tl-tabs', lazy: true },
   { component: TlTabComponent, selector: 'tl-tab', lazy: true },

--- a/projects/tl-elements/src/lib/shared/tl-shared.module.ts
+++ b/projects/tl-elements/src/lib/shared/tl-shared.module.ts
@@ -8,6 +8,8 @@ import { TlAlertComponent } from '../tl-alert/tl-alert.component';
 import { TlButtonComponent } from '../tl-button/tl-button.component';
 import { TlCardComponent } from '../tl-card/tl-card.component';
 import { TlDropDownComponent } from '../tl-dropdown/tl-dropdown.component';
+import { TlDropDownMenuSectionComponent } from '../tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component';
+import { TlDropDownMenuComponent } from '../tl-dropdown-menu/tl-dropdown-menu.component';
 import { TlFooterComponent } from '../tl-footer/tl-footer.component';
 import { TlHeaderComponent } from '../tl-header/tl-header.component';
 import { TlIconComponent } from '../tl-icon/tl-icon.component';
@@ -27,6 +29,8 @@ export const TL_COMPONENTS = [
   TlButtonComponent,
   TlCardComponent,
   TlDropDownComponent,
+  TlDropDownMenuSectionComponent,
+  TlDropDownMenuComponent,
   TlFooterComponent,
   TlHeaderComponent,
   TlItWorksComponent,

--- a/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component.html
+++ b/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component.html
@@ -1,0 +1,5 @@
+<wvr-nav-list-component vertical="true" class="section-content" [ngClass]="{ 'mobile-layout': isMobileLayout }">
+  <template nav-list-items>
+    <ng-content select="tl-nav-li, tl-dropdown-menu-custom" ngProjectAs="wvr-nav-li"></ng-content>
+  </template>
+</wvr-nav-list-component>

--- a/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component.scss
+++ b/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component.scss
@@ -1,0 +1,62 @@
+@import "../../shared/styles/tl-variables.scss";
+
+:host {
+  width: 27%;
+  padding-bottom: 35px;
+
+  wvr-nav-list-component.mobile-layout {
+    display: inline-block;
+    overflow: hidden;
+    transition: max-height 0.25s ease-in-out;
+  }
+
+  wvr-nav-list-component.mobile-layout.active {
+    max-height: var(--wvr-nav-list-component-max-height);
+    transition: max-height 1s ease-in-out;
+  }
+
+  p {
+    margin-bottom: 3px;
+  }
+
+  wvr-nav-list-component {
+    ::ng-deep {
+      ul {
+        height: auto;
+      }
+
+      tl-nav-li {
+        padding: 4px 0px 6px 25px;
+        margin-bottom: 2px;
+        color: var(--tl-deep-grey);
+        font-weight: lighter;
+        width: 100%;
+        display: block;
+
+        > a {
+          padding: 0px;
+          margin-bottom: 0x;
+          color: inherit;
+          font-weight: inherit;
+          width: 100%;
+          display: block;
+        }
+
+        > a:hover {
+          font-weight: inherit;
+          color: inherit;
+          background: inherit;
+          text-decoration: none;
+        }
+      }
+
+      tl-nav-li:hover {
+        font-weight: bolder;
+        color: var(--tl-white);
+        background: var(--tl-deep-grey);
+        text-decoration: none;
+      }
+    }
+  }
+
+}

--- a/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component.spec.ts
+++ b/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component.spec.ts
@@ -1,0 +1,56 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { provideMockStore } from '@ngrx/store/testing';
+import { APP_CONFIG, testAppConfig } from '@wvr/elements';
+import { TLSharedModule } from '../../shared/tl-shared.module';
+import { TlDropDownMenuComponent } from '../tl-dropdown-menu.component';
+import { TlDropDownMenuSectionComponent } from './tl-dropdown-menu-section.component';
+
+describe('TlDropDownMenuSectionComponent', () => {
+  let component: TlDropDownMenuSectionComponent;
+  let fixture: ComponentFixture<TlDropDownMenuSectionComponent>;
+  let parentComponent: TlDropDownMenuComponent;
+  let parentFixture: ComponentFixture<TlDropDownMenuComponent>;
+  const initialState = {
+    theme: {
+      themes: {}
+    }
+  };
+
+  beforeEach(waitForAsync(() => TestBed.configureTestingModule({
+    imports: [
+      BrowserAnimationsModule,
+      HttpClientTestingModule,
+      TLSharedModule
+    ],
+    declarations: [
+      TlDropDownMenuSectionComponent
+    ],
+    providers: [
+      provideMockStore({ initialState }),
+      {
+        provide: APP_CONFIG,
+        useValue: testAppConfig
+      }
+    ]
+  })
+    .compileComponents()));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TlDropDownMenuSectionComponent);
+    component = fixture.componentInstance;
+    parentFixture = TestBed.createComponent(TlDropDownMenuComponent);
+    parentComponent = parentFixture.componentInstance;
+    // tslint:disable-next-line:no-string-literal
+    component['parent'] = parentComponent;
+    fixture.detectChanges();
+    parentFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component)
+      .toBeTruthy();
+  });
+
+});

--- a/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component.ts
+++ b/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component.ts
@@ -1,0 +1,69 @@
+import { AfterContentInit, ChangeDetectionStrategy, Component, HostBinding, Injector, Input, OnInit } from '@angular/core';
+import { TamuAbstractBaseComponent } from '../../shared/tl-abstract-base.component';
+import { TlDropDownMenuComponent } from '../tl-dropdown-menu.component';
+
+@Component({
+  selector: 'tl-dropdown-menu-section-component',
+  templateUrl: './tl-dropdown-menu-section.component.html',
+  styleUrls: ['./tl-dropdown-menu-section.component.scss'],
+  changeDetection: ChangeDetectionStrategy.Default
+})
+export class TlDropDownMenuSectionComponent extends TamuAbstractBaseComponent implements AfterContentInit, OnInit  {
+
+  private parent: TlDropDownMenuComponent;
+
+  /** Toggles the mobile-layout class on the root element. */
+  @HostBinding('class.mobile-layout') mobileLayout = this.isMobileLayout;
+
+  /** Allows for the override of the --tl-mobile-display-wvr-nav-list-component-max-height variable. */
+  @HostBinding('style.--wvr-nav-list-component-max-height') wvrNavListComponentMaxHeight: string;
+
+  constructor(injector: Injector) {
+    super(injector);
+  }
+
+  /**
+   * Perform initialization operations.
+   *
+   * This will identify the parent element.
+   *
+   * @returns {void}
+   */
+  ngOnInit(): void {
+    super.ngOnInit();
+
+    const elem = this.eRef.nativeElement as HTMLElement;
+    const parentElem = elem.closest('tl-dropdown-menu');
+
+    if (parentElem) {
+      this.parent = this.componentRegistry.getComponentByElement(parentElem as HTMLElement) as TlDropDownMenuComponent;
+    } else {
+      console.warn(`TlDropDownMenuSectionComponent (${this.id}) is not within a TlDropDownMenuComponent`);
+    }
+  }
+
+  /**
+   * Perform after-initialization operations.
+   *
+   * This will add the section to the parent's component.
+   *
+   * @returns {void}
+   */
+  ngAfterContentInit(): void {
+    super.ngAfterContentInit();
+
+    setTimeout(() => {
+      this.parent.addSection(this);
+    }, 1500);
+  }
+
+  /**
+   * Get the clientHeight of the element.
+   *
+   * @returns {number} the height of the element, in pixels.
+   */
+  getElementHeight(): number {
+    return (this.eRef.nativeElement as HTMLElement).clientHeight;
+  }
+
+}

--- a/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu.component.html
+++ b/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu.component.html
@@ -1,0 +1,56 @@
+<wvr-dropdown-component
+  [themeVariant]="'link'"
+  [toggleOn]="'mouseover'"
+  [menuYOffset]="'-2px'"
+  [menuWidth]="menuWidth"
+  [btnTextDecoration]="'none'"
+  [btnColor]="'var(--tl-black)'"
+  [btnFontWeight]="'bolder'"
+  [btnColorHover]="'var(--tl-black)'"
+  [btnTextDecorationHover]="'none'"
+  [btnFontFamily]="'var(--tl-font-family-sans-serif)'"
+  [ngClass]="{active: active}"
+  [openDelay]="openDelay"
+  ngbDropdownAnchor>
+  <template dropdown-button>
+    <span (click)="toggleMobileMenuOpen()">
+      {{menuTitle}}
+      <tl-icon-component
+        class="x-icon"
+        [hiddenInMobile]="true"
+        [set]="'bootstrap'"
+        [name]="'caret-right-fill'"
+        [size]="'11px'">
+      </tl-icon-component>
+      <tl-icon-component
+        class="plus-icon"
+        [set]="'bootstrap'"
+        [name]="'plus'"
+        [size]="'24px'">
+      </tl-icon-component>
+    </span>
+  </template>
+  <template dropdown-menu>
+    <div *ngIf="!isMobileLayout" class="dropdown-menu-custom-top">
+      <div>
+        <ng-content select="tl-dropdown-menu-custom[top-content]"></ng-content>
+      </div>
+    </div>
+    <div *ngIf="!isMobileLayout" class="dropdown-menu-sections">
+      <ng-container *ngTemplateOutlet="sections"></ng-container>
+    </div>
+    <div *ngIf="!isMobileLayout" class="dropdown-menu-custom-bottom">
+      <div>
+        <ng-content select="tl-dropdown-menu-custom[bottom-content]"></ng-content>
+      </div>
+    </div>
+  </template>
+</wvr-dropdown-component>
+
+<div *ngIf="isMobileLayout" class="mobile-display" [ngClass]="{active: active}">
+  <ng-container *ngTemplateOutlet="sections"></ng-container>
+</div>
+
+<ng-template #sections>
+  <ng-content select="tl-dropdown-menu-section"></ng-content>
+</ng-template>

--- a/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu.component.scss
+++ b/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu.component.scss
@@ -5,13 +5,8 @@
   font-family: var(--tl-font-family-sans-serif);
   --tl-mobile-display-max-height: 1500px;
 
-  .mega-menu-sections {
-    margin: 0px 20px;
-  }
-
-  .mega-menu-view-all {
-    display: flex;
-    justify-content: flex-end;
+  .dropdown-menu-sections {
+    margin: 0px 0px;
   }
 
   wvr-dropdown-component {
@@ -26,6 +21,15 @@
 
         .btn {
           width: 100%;
+
+          .menu-title {
+            display: inline;
+          }
+
+          a.menu-title:hover {
+            text-decoration: none !important;
+            color: var(--tl-white) !important;
+          }
 
           tl-icon-component.x-icon svg {
             transition: transform 0.25s ease-in-out;
@@ -74,41 +78,14 @@
     background: var(--tl-grey);
 
     ::ng-deep {
-      tl-mega-menu-section-component,
-      tl-mega-menu-section {
+      tl-dropdown-menu-section-component,
+      tl-dropdown-menu-section {
         display: flex;
         flex-direction: column;
         width: 100%;
         padding: 0px;
 
-        a {
-          margin: 0px 15px 0px 0px;
-          padding: 20px 0px 0px 60px;
-          text-align: start;
-          color: var(--tl-black);
-          font-size: 17px;
-          font-family: var(--tl-font-family-sans-serif);
-          font-weight: 300;
-
-          wvre-text {
-            font-weight: 400;
-            padding: 0px;
-            margin: 0px;
-            border-bottom: 0.5px solid #e4e4e4;
-            display: flex;
-            height: 40px;
-            width: 97%;
-          }
-        }
-
-        a:hover {
-          border-bottom: none;
-          wvre-text {
-            border-bottom: none;
-          }
-        }
-
-        .section-title {
+        .section-content .navbar-nav tl-nav-li {
           cursor: pointer;
           margin: 0px 15px 0px 30px;
           padding: 20px 0px;
@@ -119,17 +96,36 @@
           font-weight: 300;
           border-bottom: 0.5px solid #e4e4e4;
           text-decoration: none;
+
+          > a {
+            padding: 0px;
+            margin-bottom: 0x;
+            color: inherit;
+            font-weight: inherit;
+            width: 100%;
+            display: block;
+          }
+
+          > a:hover {
+            font-weight: inherit;
+            color: inherit;
+            background: inherit;
+            text-decoration: none;
+          }
+
+          wvre-text {
+            display: flex;
+            font-weight: 300;
+            padding: 0px;
+            margin: 0px;
+          }
         }
 
-        a.mega-menu-view-all {
-          cursor: pointer;
-          margin: 0px 15px 0px 30px;
-          padding: 20px 0px;
-          text-align: start;
-          color: var(--tl-black);
-          font-size: 17px;
-          font-family: var(--tl-font-family-sans-serif);
-          font-weight: 300;
+        .section-content .navbar-nav tl-nav-li:hover {
+          border-bottom: none;
+          color: inherit;
+          background-color: inherit;
+
           border-bottom: 0.5px solid #e4e4e4;
         }
       }

--- a/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu.component.spec.ts
+++ b/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu.component.spec.ts
@@ -1,0 +1,77 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { provideMockStore } from '@ngrx/store/testing';
+import { APP_CONFIG, testAppConfig } from '@wvr/elements';
+import { TLSharedModule } from '../shared/tl-shared.module';
+import { TlDropDownMenuComponent } from './tl-dropdown-menu.component';
+
+describe('TlDropDownMenuComponent', () => {
+  let component: TlDropDownMenuComponent;
+  let fixture: ComponentFixture<TlDropDownMenuComponent>;
+  let debugElement: DebugElement;
+  const initialState = {
+    theme: {
+      themes: {}
+    }
+  };
+
+  beforeEach(waitForAsync(() => TestBed.configureTestingModule({
+    imports: [
+      BrowserAnimationsModule,
+      HttpClientTestingModule,
+      TLSharedModule
+    ],
+    declarations: [TlDropDownMenuComponent],
+    providers: [
+      provideMockStore({ initialState }),
+      {
+        provide: APP_CONFIG,
+        useValue: testAppConfig
+      }
+    ]
+  })
+    .compileComponents()));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TlDropDownMenuComponent);
+    debugElement = fixture.debugElement;
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component)
+      .toBeTruthy();
+  });
+
+  it("should have as default menuTitle 'Dropdown Menu'", () => {
+    expect(component.menuTitle)
+      .toEqual('Dropdown Menu');
+  });
+
+  it("should have as default menuWidth 'auto'", () => {
+    expect(component.menuWidth)
+      .toEqual('auto');
+  });
+
+  it('toggleMobileMenuOpen should toggle active class', () => {
+    const tlDropDownMenu = (fixture.elementRef.nativeElement as HTMLElement);
+    const wvrDropDownMenuElement = tlDropDownMenu.querySelector('wvr-dropdown-component');
+
+    expect(component.active)
+      .toBeFalse();
+
+    component.toggleMobileMenuOpen();
+
+    expect(component.active)
+      .toBeTrue();
+
+    component.toggleMobileMenuOpen();
+
+    expect(component.active)
+      .toBeFalse();
+  });
+
+});

--- a/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu.component.ts
+++ b/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu.component.ts
@@ -1,0 +1,65 @@
+/* istanbul ignore file */
+
+import { AfterContentInit, ChangeDetectionStrategy, Component, HostBinding, HostListener, Injector, Input } from '@angular/core';
+import { debounce, wvrTimeout } from '@wvr/elements';
+import { TamuAbstractBaseComponent } from '../shared/tl-abstract-base.component';
+import { TlDropDownMenuSectionComponent } from './tl-dropdown-menu-section/tl-dropdown-menu-section.component';
+
+@Component({
+  selector: 'tl-dropdown-menu-component',
+  templateUrl: './tl-dropdown-menu.component.html',
+  styleUrls: ['./tl-dropdown-menu.component.scss'],
+  changeDetection: ChangeDetectionStrategy.Default
+})
+export class TlDropDownMenuComponent extends TamuAbstractBaseComponent implements AfterContentInit {
+
+  /** The default text value to be displayed as the menu title. */
+  @Input() menuTitle = 'Dropdown Menu';
+
+  /** Designate the menu width. */
+  @Input() menuWidth = 'auto';
+
+  /** Determine the delay in milliseconds the dropdown takes prior to display on mouse hover. */
+  @Input() openDelay = 500;
+
+  /** Allows for the override of the --tl-mobile-display-max-height variable. */
+  @HostBinding('style.--tl-mobile-display-max-height') mobileDisplayMaxHeight = '0px';
+
+  /** Designate whether the menu is opened or closed. */
+  active = false;
+
+  /** The height of to use for each section. */
+  private sectionHeight = 0;
+
+  /** A container for all menu sections attached to this menu. */
+  private readonly sections: Array<TlDropDownMenuSectionComponent> = [];
+
+  /**
+   * Append a section to the menu.
+   *
+   * The section title height will be auto-adjusted based on the added section.
+   *
+   * @param {TlDropDownMenuSectionComponent} The section to append.
+   *
+   * @returns {void}
+   */
+  addSection(section: TlDropDownMenuSectionComponent): void {
+    this.sections.push(section);
+
+    const height = section.getElementHeight();
+    if (height > this.sectionHeight) {
+      this.sectionHeight = height;
+    }
+  }
+
+  /**
+   * Toggles the mobile view menu open or closed.
+   *
+   * @returns {void}
+   */
+  toggleMobileMenuOpen(): void {
+    this.mobileDisplayMaxHeight = `${this.sections.length * this.sectionHeight}px`;
+    this.active = !this.active;
+  }
+
+}

--- a/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu.component.ud-examples.html
+++ b/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu.component.ud-examples.html
@@ -1,0 +1,64 @@
+<example name="Example Dropdown Basic">
+  <desciption>
+    The basic <code>tl-dropdown-menu</code> component with no customizations.
+  </desciption>
+  <snippet>
+
+  <tl-dropdown-menu menu-title="Example Dropdown">
+    <tl-dropdown-menu-section>
+      <tl-nav-li>
+        <a href="/research/option1">
+          <wvre-text value="Option 1"></wvre-text>
+        </a>
+      </tl-nav-li>
+    </tl-dropdown-menu-section>
+    <tl-dropdown-menu-section>
+      <tl-nav-li>
+        <a href="/research/option2">
+          <wvre-text value="Option 2"></wvre-text>
+        </a>
+      </tl-nav-li>
+    </tl-dropdown-menu-section>
+    <tl-dropdown-menu-section>
+      <tl-nav-li>
+        <a href="/research/option3">
+          <wvre-text value="Option 3"></wvre-text>
+        </a>
+      </tl-nav-li>
+    </tl-dropdown-menu-section>
+  </tl-dropdown-menu>
+  </snippet>
+</example>
+
+<example name="Example Dropdown Customized">
+  <desciption>
+    The basic <code>tl-dropdown-menu</code> component with a set width for the sections and hidden in mobile enabled.
+  </desciption>
+  <snippet>
+  <tl-dropdown-menu menu-title="Alternate Dropdown"
+    menu-width="200px"
+    hidden-in-mobile="true">
+    <tl-dropdown-menu-section>
+      <tl-nav-li>
+        <a href="/research/option1">
+          <wvre-text value="Option 1"></wvre-text>
+        </a>
+      </tl-nav-li>
+    </tl-dropdown-menu-section>
+    <tl-dropdown-menu-section>
+      <tl-nav-li>
+        <a href="/research/option2">
+          <wvre-text value="Option 2"></wvre-text>
+        </a>
+      </tl-nav-li>
+    </tl-dropdown-menu-section>
+    <tl-dropdown-menu-section>
+      <tl-nav-li>
+        <a href="/research/option3">
+          <wvre-text value="Option 3"></wvre-text>
+        </a>
+      </tl-nav-li>
+    </tl-dropdown-menu-section>
+  </tl-dropdown-menu>
+  </snippet>
+</example>

--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.scss
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.scss
@@ -17,6 +17,7 @@
 
     .title-row {
       background-color: var(--primary-default-bg);
+
       a span {
         color: var(--primary-default-color);
       }
@@ -105,8 +106,10 @@
         a {
           text-decoration: none;
         }
+
         .libraries-link {
           margin-bottom: 18px;
+
           a {
             color: var(--primary);
             text-decoration: underline;
@@ -115,6 +118,7 @@
 
         p {
           color: var(--primaryNeutral);
+
           a {
             color: #2b5d7d;
             wvr-text-component {
@@ -128,12 +132,14 @@
         wvre-dropdown-menu-item {
           display: block;
         }
+
         a {
           color: var(--secondary-default-hover-bg);
           text-decoration: none;
           line-height: 2;
           padding: 10px 20px;
         }
+
         a:hover {
           color: var(--secondary-default-bg);
         }
@@ -147,6 +153,7 @@
         .wvr-button {
           color: var(--tl-white);
         }
+
         .wvr-button:hover {
           color: var(--tl-black);
         }
@@ -155,12 +162,14 @@
           border-bottom: 1px solid var(--light);
           padding: 10px 0px;
           display: flex;
+
           a {
             color: var(--primary-default-bg);
             padding: 8px 0px 8px 8px;
             text-decoration: none;
             width: 100%;
           }
+
           tl-icon-component svg {
             fill: var(--dark);
             width: 35px;
@@ -203,6 +212,7 @@
         }
       }
     }
+
     wvr-nav-list-component[bottom-navigation]
     wvr-nav-li-component.call-to-action:hover {
       a {
@@ -230,12 +240,14 @@
       --wvr-nav-link-color-hover: var(--tl-white);
       --wvr-nav-link-background-hover: var(--dark);
       width: fit-content;
+
       .nav-item > a wvre-text {
         font-family: var(--tl-font-family-sans-serif);
         font-weight: 700;
         font-size: 16px;
         color: var(--tl-black);
       }
+
       .nav-item > a.nav-link {
         display: flex;
         align-items: center;
@@ -252,29 +264,36 @@
         }
       }
 
+      tl-dropdown-menu,
       tl-mega-menu {
         display: flex;
         height: 100%;
         width: 100%;
+
         wvr-dropdown-component {
           display: flex;
           height: 100%;
           width: 100%;
+
           .wvr-dropdown {
             width: 100%;
             .dropdown {
               height: 100%;
               width: 100%;
+
               wvre-text {
                 font-size: var(--tl-font-size);
               }
+
               wvr-button-component {
                 margin-top: 1px;
                 display: flex;
                 height: 100%;
                 width: 100%;
+
                 button-wrapper {
                   width: 100%;
+
                   button {
                     height: 100%;
                     width: 100%;
@@ -299,9 +318,11 @@
     .top-nav {
       border-bottom: 1px solid var(--primaryNeutral);
       background: var(--primaryAccent-default-bg);
+
       .navbar-brand wvre-text-node {
         color: var(--primaryAccent-default-color);
       }
+
       .container {
         > div {
           height: auto;
@@ -325,10 +346,12 @@
 
       .top-nav {
         border-bottom: 1px solid var(--primaryNeutral);
+
         .container {
           > div {
             width: 100%;
           }
+
           > a.navbar-brand {
             margin: auto;
           }
@@ -343,6 +366,7 @@
         width: 100%;
         background: var(--tl-deep-yellow);
         border-bottom: 1px solid var(--secondaryNeutral);
+
         wvre-text {
           font-family: var(--tl-font-family-sans-serif);
           font-weight: 600;
@@ -380,6 +404,7 @@
           wvr-button-component {
             display: flex;
             width: 100%;
+
             button-wrapper {
               width: 100%;
               .btn {
@@ -394,6 +419,7 @@
             padding-top: 6px !important;
             padding-bottom: 6px !important;
             margin-top: 0px !important;
+
             div[dropdown-button],
             wvr-text-component,
             wvre-text {
@@ -410,29 +436,36 @@
         text-align: center;
       }
 
+      tl-dropdown-menu,
       tl-mega-menu {
         width: 100%;
         background: var(--tl-deep-yellow);
         overflow: hidden;
         border-bottom: var(--secondaryNeutral);
+
         wvr-dropdown-component {
           display: flex;
           width: 100%;
+
           .wvr-dropdown {
             display: flex !important;
             width: 100%;
+
             .dropdown {
               display: flex !important;
               width: 100%;
+
               wvr-button-component {
                 display: flex;
                 width: 100%;
+
                 button-wrapper {
                   display: flex;
                   width: 100%;
                   height: 68px;
                   align-items: center;
                   border-bottom: thin solid var(--secondaryNeutral);
+
                   button {
                     display: flex;
                     width: 100%;
@@ -459,6 +492,7 @@
       }
     }
   }
+
   .mobile-menu-button {
     display: none;
     margin-left: 10px;
@@ -476,21 +510,33 @@
     left: 0;
     z-index: 1100;
     transition: width 0.5s ease-in-out, opacity 0.5s ease-in-out;
+
     div.mobile-menu-content {
       wvre-nav-li > li.nav-item {
         a {
           white-space: nowrap;
         }
+
+        .mobile-display tl-dropdown-menu-section-component,
+        .mobile-display tl-dropdown-menu-section
         .mobile-display tl-mega-menu-section-component,
         .mobile-display tl-mega-menu-section {
           white-space: nowrap;
         }
+
+        tl-dropdown-menu
+          > wvr-dropdown-component
+          > .wvr-dropdown
+          .dropdown
+          wvr-button-component,
         tl-mega-menu
           > wvr-dropdown-component
           > .wvr-dropdown
           .dropdown
           wvr-button-component {
+
           white-space: nowrap;
+
           span[button-content] {
             width: 100%;
             span {
@@ -500,6 +546,7 @@
           }
         }
       }
+
       wvr-nav-li-component.call-to-action {
         a {
           color: var(--tl-black);
@@ -513,6 +560,7 @@
           text-decoration: none;
           font-weight: 700;
         }
+
         tl-icon-component svg {
           display: none;
         }

--- a/projects/tl-elements/src/lib/tl-mega-menu/tl-mega-menu-section/tl-mega-menu-section.component.scss
+++ b/projects/tl-elements/src/lib/tl-mega-menu/tl-mega-menu-section/tl-mega-menu-section.component.scss
@@ -1,12 +1,11 @@
 @import "../../shared/styles/tl-variables.scss";
 
-
 :host {
-
   --wvr-nav-list-component-max-height: 450px;
 
   width: 27%;
   padding-bottom: 35px;
+
   .section-title {
     padding-bottom: 3px;
     color: var(--tl-primary);
@@ -15,7 +14,6 @@
     border-bottom: 2px solid var(--tl-primary);
   }
 
-
   .section-title.mobile-layout {
     tl-icon-component {
       float: right;
@@ -23,6 +21,7 @@
       transform: rotate(0deg);
     }
   }
+
   .section-title.mobile-layout.active {
     tl-icon-component {
       float: right;
@@ -30,6 +29,7 @@
       transform: rotate(90deg);
     }
   }
+
   wvr-nav-list-component.mobile-layout {
     display: inline-block;
     overflow: hidden;
@@ -49,14 +49,13 @@
 
   wvr-nav-list-component {
     ::ng-deep {
-      
       ul{
         height: auto;
       }
 
       tl-nav-li {
         width: 100%;
-                 
+
         a {
           padding: 4px 0px 6px 25px;
           margin-bottom:2px;
@@ -65,6 +64,7 @@
           width: 100%;
           display: block;
         }
+
         a:hover {
           font-weight: bolder;
           color: var(--tl-white);

--- a/projects/tl-elements/src/lib/tl-mega-menu/tl-mega-menu-section/tl-mega-menu-section.component.ts
+++ b/projects/tl-elements/src/lib/tl-mega-menu/tl-mega-menu-section/tl-mega-menu-section.component.ts
@@ -38,7 +38,7 @@ export class TlMegaMenuSectionComponent extends TamuAbstractBaseComponent implem
     if (parentElem) {
       this.parent = this.componentRegistry.getComponentByElement(parentElem as HTMLElement) as TlMegaMenuComponent;
     } else {
-      console.warn(`TlMegaMenuSectionComponent (${this.id}) is not within a TLMegamMenuComponent`);
+      console.warn(`TlMegaMenuSectionComponent (${this.id}) is not within a TlMegaMenuComponent`);
     }
   }
 

--- a/projects/tl-elements/src/lib/tl-mega-menu/tl-mega-menu.component.ts
+++ b/projects/tl-elements/src/lib/tl-mega-menu/tl-mega-menu.component.ts
@@ -12,6 +12,7 @@ import { TlMegaMenuSectionComponent } from './tl-mega-menu-section/tl-mega-menu-
   changeDetection: ChangeDetectionStrategy.Default
 })
 export class TlMegaMenuComponent extends TamuAbstractBaseComponent implements AfterContentInit {
+
   /** The default text value to be displayed for tl-mega menu title. */
   @Input() menuTitle = 'Mega Menu';
 

--- a/projects/tl-elements/src/public-api.ts
+++ b/projects/tl-elements/src/public-api.ts
@@ -8,6 +8,8 @@ export * from './lib/tl-alert/tl-alert.component';
 export * from './lib/tl-button/tl-button.component';
 export * from './lib/tl-card/tl-card.component';
 export * from './lib/tl-dropdown/tl-dropdown.component';
+export * from './lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component';
+export * from './lib/tl-dropdown-menu/tl-dropdown-menu.component';
 export * from './lib/tl-footer/tl-footer.component';
 export * from './lib/tl-header/tl-header.component';
 export * from './lib/tl-icon/tl-icon.component';

--- a/src/index.html
+++ b/src/index.html
@@ -80,7 +80,7 @@
               </a>
             </tl-nav-li>
           </tl-mega-menu-section>
-  
+
           <tl-mega-menu-section section-title="Researcher Services">
             <tl-nav-li>
               <a href="https://library.tamu.edu/services/scholarly_communication/index.html">
@@ -123,7 +123,7 @@
               </a>
             </tl-nav-li>
           </tl-mega-menu-section>
-  
+
           <tl-mega-menu-section section-title="Instructional Services">
             <tl-nav-li>
               <a href="https://library.tamu.edu/libraryInstruction/index.html">
@@ -161,7 +161,7 @@
               </a>
             </tl-nav-li>
           </tl-mega-menu-section>
-  
+
           <tl-mega-menu-section section-title="Information For">
             <tl-nav-li>
               <a href="faculty_info/index.html">
@@ -199,7 +199,7 @@
               </a>
             </tl-nav-li>
           </tl-mega-menu-section>
-  
+
           <tl-mega-menu-section section-title="Technology">
             <tl-nav-li>
               <a href="https://library.tamu.edu/libraryInstruction/the-studio.html">
@@ -227,7 +227,7 @@
               </a>
             </tl-nav-li>
           </tl-mega-menu-section>
-  
+
           <tl-mega-menu-section section-title="Additional Services">
             <tl-nav-li>
               <a href="http://getitforme.library.tamu.edu/">
@@ -262,7 +262,7 @@
           </tl-mega-menu-section>
         </tl-mega-menu>
       </wvre-nav-li>
-  
+
       <wvre-nav-li>
         <tl-mega-menu menu-title="Research" view-all-href="/research/">
           <tl-mega-menu-section section-title="Search and Find">
@@ -297,7 +297,7 @@
               </a>
             </tl-nav-li>
           </tl-mega-menu-section>
-  
+
           <tl-mega-menu-section section-title="Get It for Me">
             <tl-nav-li>
               <a href="http://getitforme.library.tamu.edu/">
@@ -320,7 +320,7 @@
               </a>
             </tl-nav-li>
           </tl-mega-menu-section>
-  
+
           <tl-mega-menu-section section-title="Library Help and How-Tos">
             <tl-nav-li>
               <a href="http://askus.library.tamu.edu/">
@@ -353,7 +353,7 @@
               </a>
             </tl-nav-li>
           </tl-mega-menu-section>
-  
+
           <tl-mega-menu-section section-title="Popular Databases">
             <tl-nav-li>
               <a href="http://proxy.library.tamu.edu/login?url=https://coral.library.tamu.edu/resourcelink.php?resource=10096">
@@ -391,7 +391,7 @@
               </a>
             </tl-nav-li>
           </tl-mega-menu-section>
-  
+
           <tl-mega-menu-section section-title="Citing and Writing">
             <tl-nav-li>
               <a href="http://tamu.libguides.com/citationbasics">
@@ -424,7 +424,7 @@
               </a>
             </tl-nav-li>
           </tl-mega-menu-section>
-  
+
           <tl-mega-menu-section section-title="Researcher Services">
             <tl-nav-li>
               <a href="https://library.tamu.edu/services/scholarly_communication/index.html">
@@ -565,7 +565,7 @@
           </tl-mega-menu-section>
         </tl-mega-menu>
       </wvre-nav-li>
-  
+
       <wvre-nav-li>
         <tl-mega-menu menu-title="Collections" view-all-href="/borrowing/" hidden-in-mobile="true">
           <tl-mega-menu-section section-title="Borrowing">
@@ -948,16 +948,16 @@
       </template>
     </tl-alert>
   </div>
-  <br />
-  <hr />
-  <br />
-  <div class="container" style="text-align: center;">
-    <wvre-text value="DropDown Component" text-decoration="underline"></wvre-text><br /><br />
 
-    <tl-drop-down theme-variant="primary" hidden-in-mobile="true">
+  <br><hr><br>
+
+  <div class="container" style="text-align: center;">
+    <wvre-text value="DropDown Component" text-decoration="underline"></wvre-text><br><br>
+
+    <tl-dropdown theme-variant="primary" hidden-in-mobile="true">
       <template dropdown-button>
-          <wvre-text value="Primary Dropdown"></wvre-text>
-        </template>
+        <wvre-text value="Primary Dropdown"></wvre-text>
+      </template>
       <template dropdown-menu>
         <wvre-dropdown-menu-item>
           <wvre-text value="Drop Down Item 1"></wvre-text>
@@ -969,9 +969,9 @@
           <wvre-text value="Drop Down Item 3"></wvre-text>
         </wvre-dropdown-menu-item>
       </template>
-    </tl-drop-down>
+    </tl-dropdown>
 
-    <tl-drop-down theme-variant="secondary">
+    <tl-dropdown theme-variant="secondary">
       <template dropdown-button>
         <wvre-text value=" Secondary Dropdown"></wvre-text>
       </template>
@@ -986,9 +986,9 @@
           <wvre-text value="Drop Down Item 3"></wvre-text>
         </wvre-dropdown-menu-item>
       </template>
-    </tl-drop-down>
+    </tl-dropdown>
 
-    <tl-drop-down theme-variant="success">
+    <tl-dropdown theme-variant="success">
       <template dropdown-button>
         <wvre-text value=" Success Dropdown "></wvre-text>
       </template>
@@ -1003,9 +1003,9 @@
           <wvre-text value="Drop Down Item 3"></wvre-text>
         </wvre-dropdown-menu-item>
       </template>
-    </tl-drop-down>
+    </tl-dropdown>
 
-    <tl-drop-down theme-variant="info">
+    <tl-dropdown theme-variant="info">
       <template dropdown-button>
         <wvre-text value=" Info Dropdown "></wvre-text>
       </template>
@@ -1020,9 +1020,9 @@
           <wvre-text value="Drop Down Item 3"></wvre-text>
         </wvre-dropdown-menu-item>
       </template>
-    </tl-drop-down>
+    </tl-dropdown>
 
-    <tl-drop-down theme-variant="warning">
+    <tl-dropdown theme-variant="warning">
       <template dropdown-button>
         <wvre-text value=" Warning Dropdown "></wvre-text>
       </template>
@@ -1037,9 +1037,9 @@
           <wvre-text value="Drop Down Item 3"></wvre-text>
         </wvre-dropdown-menu-item>
       </template>
-    </tl-drop-down>
+    </tl-dropdown>
 
-    <tl-drop-down theme-variant="danger">
+    <tl-dropdown theme-variant="danger">
       <template dropdown-button>
         <wvre-text value=" Danger Dropdown "></wvre-text>
       </template>
@@ -1054,9 +1054,9 @@
           <wvre-text value="Drop Down Item 3"></wvre-text>
         </wvre-dropdown-menu-item>
       </template>
-    </tl-drop-down>
+    </tl-dropdown>
 
-    <tl-drop-down theme-variant="dark">
+    <tl-dropdown theme-variant="dark">
       <template dropdown-button>
         <wvre-text value=" Dark Dropdown "></wvre-text>
       </template>
@@ -1071,9 +1071,9 @@
           <wvre-text value="Drop Down Item 3"></wvre-text>
         </wvre-dropdown-menu-item>
       </template>
-    </tl-drop-down>
+    </tl-dropdown>
 
-    <tl-drop-down theme-variant="light">
+    <tl-dropdown theme-variant="light">
       <template dropdown-button>
         <wvre-text value=" Light Dropdown "></wvre-text>
       </template>
@@ -1088,9 +1088,9 @@
           <wvre-text value="Drop Down Item 3"></wvre-text>
         </wvre-dropdown-menu-item>
       </template>
-    </tl-drop-down>
+    </tl-dropdown>
 
-    <tl-drop-down btn-type="link">
+    <tl-dropdown btn-type="link">
       <template dropdown-button>
         <wvre-text value="Link Dropdown "></wvre-text>
       </template>
@@ -1105,11 +1105,11 @@
           <wvre-text value="Drop Down Item 3"></wvre-text>
         </wvre-dropdown-menu-item>
       </template>
-    </tl-drop-down>
+    </tl-dropdown>
   </div>
-  <br />
-  <hr />
-  <br />
+
+  <br><hr><br>
+
   <div class="container" style="text-align: center;">
     <wvre-text value="Button Component" text-decoration="underline"></wvre-text><br /><br />
     <tl-button theme-variant="primary" animate="{click: 'rotateToggle'}">
@@ -1173,17 +1173,21 @@
       </template>
     </tl-button>
   </div>
-  <br /><hr /><br />
+
+  <br><hr><br>
+
   <div class="container" style="text-align: center;background: #6d6d6d;">
     <wvre-text value="Icon Component" text-decoration="underline"></wvre-text><br /><br />
     <tl-icon size="64px"></tl-icon>
     <tl-icon set="tl" name="weaver-w" color="#500000" size="32px" hidden-in-mobile="true"></tl-icon>
     <tl-icon set="bootstrap" name="arrow-right-circle" size="32px" animate="{click: 'rotateToggle'}"></tl-icon>
   </div>
-  <br /><hr /><br />
+
+  <br><hr><br>
+
   <!-- style="height: 700px;" -->
-  <div class="container" >
-    <wvre-text value="Mega Menu Component" text-decoration="underline"></wvre-text><br /><br />
+  <div class="container">
+    <wvre-text value="Mega Menu Component" text-decoration="underline" style="text-align: center;"></wvre-text><br /><br />
     <tl-mega-menu menu-title="Services"
                   view-all-href="/view-all"
                   view-all-button-text= "Customized View All Button"
@@ -1282,13 +1286,46 @@
         </div>
       </tl-mega-menu-custom>
     </tl-mega-menu>
-
   </div>
 
+  <br><hr><br>
+
+  <div class="container" style="text-align: center;">
+    <wvre-text value="Dropdown Menu Component" text-decoration="underline"></wvre-text>
+    <br><br>
+    <tl-dropdown-menu menu-title="Dropdown Menu">
+      <tl-dropdown-menu-section>
+        <tl-nav-li>
+          <a href="#1">
+            <wvre-text value="Example 1"></wvre-text>
+          </a>
+        </tl-nav-li>
+      </tl-dropdown-menu-section>
+      <tl-dropdown-menu-section>
+        <tl-nav-li>
+          <a href="#2">
+            Example 2
+          </a>
+        </tl-nav-li>
+      </tl-dropdown-menu-section>
+      <tl-dropdown-menu-section>
+        <tl-nav-li>
+          <wvre-text value="Example 3"></wvre-text>
+        </tl-nav-li>
+      </tl-dropdown-menu-section>
+      <tl-dropdown-menu-section>
+        <tl-nav-li>
+          Example 4
+        </tl-nav-li>
+      </tl-dropdown-menu-section>
+    </tl-dropdown-menu>
+  </div>
+
+  <br><hr><br>
+
   <div class="container index-container">
-
-    <wvre-text value="Wvr Store, and Communication" text-decoration="underline"></wvre-text><br /><br />
-
+    <wvre-text value="Wvr Store, and Communication" text-decoration="underline" style="text-align: center;"></wvre-text>
+    <br><br>
     <wvre-list list-type="unstyled" hidden-in-mobile="true" wvr-data="[
       {
         manifest: 'Directory App',
@@ -1302,7 +1339,6 @@
         {{/each}}
       </template>
     </wvre-list>
-
   </div>
 
   <hr><br><br><br>


### PR DESCRIPTION
This implements a TL Dropdown Menu rather than extending the TL Dropdown.
The TL Mega Menu is used as the basis such that TL Dropdown Menu is a heavily simplified version of it.

The differences between TL Mega Menu and TL Dropdown are sufficient enough that makes me believe that implementing this inside of TL Dropdown would overcomplicate things and make code harder to maintain, debug, and use.
There are structural differences between TL Dropdown and TL Dropdown Menu that are necessary at this time and these differences follow the same methodology as the TL Mega Menu.
This implementation is otherwise feature for feature and bug for bug to TL Mega Menu.

This updates the TL Header in regards to areas where the TL Mega Menu is also used.

There are styling concerns with the highlighting of the TL Dropdown Menu items when in mobile view.
The approach taken is to match the top-level link structure of TL Mega Menu (which does not highlight on hover over nor does it use bold text).

I wanted to avoid having the explicit "section" (aka TlDropDownMenuSectionComponent).
However, after some simple experimenting, I was unable to find an easy solution using `children`.

This implementation is mostly true to the design of TL Mega Menu, except in a few key places.
1) There is no recursive menu structure.
2) There are no significant limitations on what can be put inside each row, except for the requirement of `<tl-dropdown-menu-section>` and `<tl-nav-li>` elements.
3) There is no "link" (href) support at this time on the menu itself (the menu items do support links and are expected to have links).
4) The `max-height: 0px;` is not copied from the TL Mega Menu (see issue #358).
5) The mobile menu items are styled against the `<tl-nav-li>` rather than the `<a>` elements (this allows for more flexibility in content within the items).
6) This attempts to process elements only once (storing them as a `const`) in a few places to avoid potential problems with elements changing during use (this is done in very few places thus far).

This fixes some obvious typos in TL Mega Menu (`TLMegamMenuComponent` should be `TlMegaMenuComponent`).
This fixes what is either a typo or stale code in the index for TL Dropdown (There is no `tl-drop-down`, instead use `tl-dropdown`).

The following may be dropped inside the appropriate TL Header section (inside the Bottom Navigation) to test the behavior.
```
      <wvre-nav-li>
        <tl-dropdown-menu menu-title="Dropdown Menu">
          <tl-dropdown-menu-section>
            <tl-nav-li>
              <a href="#1">
                <wvre-text value="Example 1"></wvre-text>
              </a>
            </tl-nav-li>
          </tl-dropdown-menu-section>
          <tl-dropdown-menu-section>
            <tl-nav-li>
              <a href="#2">
                Example 2
              </a>
            </tl-nav-li>
          </tl-dropdown-menu-section>
          <tl-dropdown-menu-section>
            <tl-nav-li>
              <wvre-text value="Example 3"></wvre-text>
            </tl-nav-li>
          </tl-dropdown-menu-section>
          <tl-dropdown-menu-section>
            <tl-nav-li>
              Example 4
            </tl-nav-li>
          </tl-dropdown-menu-section>
        </tl-dropdown-menu>
      </wvre-nav-li>
```

resolves #336