### PR TITLE
Fix problem introduced by following linter without fully converting loop.

### DIFF
--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.ts
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.ts
@@ -85,8 +85,8 @@ export class TlHeaderComponent extends TamuAbstractBaseComponent {
     } else {
       const values = value.split(',');
 
-      for (const key of values) {
-        this.suppressTopNavList.push(values[key]
+      for (const name of values) {
+        this.suppressTopNavList.push(name
           .trim()
           .toLowerCase());
       }


### PR DESCRIPTION
The linter complained about the loop `for key in ..`.
The loop was changed to a `for key of ..`.
The problem happens because the `values[key]` should have also been changed to `key` but was not.
This resulted in a regression due to incompletely converting the loop type.
This is now fixed and `name` is used rather than `key`.