### PR TITLE
Issue 361: The TL Tabs should support the toggling and coloring of the top border of tabs.

### DIFF
--- a/projects/tl-elements/src/lib/tl-tabs/tl-tabs.component.scss
+++ b/projects/tl-elements/src/lib/tl-tabs/tl-tabs.component.scss
@@ -1,0 +1,61 @@
+@import '~@wvr/elements/styles/variables';
+
+:host {
+
+  & ::ng-deep wvr-tabs-component .nav-tabs .nav-item {
+    .nav-link {
+      border-width: 5px 1px 1px 1px;
+      border-radius: 0px;
+
+      padding: .5rem 1rem;
+    }
+
+    .nav-link:not(.active) {
+      border-color: var(--secondaryNeutral);
+      border-bottom-color: transparent;
+    }
+
+    .nav-link.active,
+    .nav-link:not(.active):hover {
+      border-color: var(--primary);
+      border-bottom-color: transparent;
+    }
+  }
+
+  @each $color, $value in $theme-colors {
+    &:is([inactive-tab-theme="#{$color}"]) ::ng-deep wvr-tabs-component .nav-tabs .nav-item {
+      .nav-link:not(.active):is([inactive-tab-theme=""]),
+      .nav-link:not(.active):is([inactive-tab-theme=""]):active,
+      .nav-link:not(.active):is([inactive-tab-theme=""]):focus,
+      .nav-link:not(.active):is([inactive-tab-theme=""]):hover {
+        border-color: var(--#{$color}) !important;
+        border-bottom-color: transparent !important;
+      }
+    }
+
+    &:is([active-tab-theme="#{$color}"]) ::ng-deep wvr-tabs-component .nav-tabs .nav-item {
+      .nav-link.active:is([active-tab-theme=""]),
+      .nav-link.active:is([active-tab-theme=""]):active,
+      .nav-link.active:is([active-tab-theme=""]):focus,
+      .nav-link.active:is([active-tab-theme=""]):hover {
+        border-color: var(--#{$color}) !important;
+        border-bottom-color: transparent !important;
+      }
+    }
+
+    & ::ng-deep wvr-tabs-component .nav-tabs .nav-item {
+      .nav-link:is([inactive-tab-theme="#{$color}"]):not(.active),
+      .nav-link:is([inactive-tab-theme="#{$color}"]):not(.active):active,
+      .nav-link:is([inactive-tab-theme="#{$color}"]):not(.active):focus,
+      .nav-link:is([inactive-tab-theme="#{$color}"]):not(.active):hover,
+      .nav-link.active:is([active-tab-theme="#{$color}"]),
+      .nav-link.active:is([active-tab-theme="#{$color}"]):active,
+      .nav-link.active:is([active-tab-theme="#{$color}"]):focus,
+      .nav-link.active:is([active-tab-theme="#{$color}"]):hover {
+        border-color: var(--#{$color}) !important;
+        border-bottom-color: transparent !important;
+      }
+    }
+  }
+
+}

--- a/projects/tl-elements/src/lib/tl-tabs/tl-tabs.component.scss
+++ b/projects/tl-elements/src/lib/tl-tabs/tl-tabs.component.scss
@@ -6,8 +6,6 @@
     .nav-link {
       border-width: 5px 1px 1px 1px;
       border-radius: 0px;
-
-      padding: .5rem 1rem;
     }
 
     .nav-link:not(.active) {


### PR DESCRIPTION
Provide a default that uses active as "primary" and inactive as "secondaryNeutral".

The `!important` is unavoidable with the current approach due to the requirement for `::ng-deep`.
The weaver styles from https://github.com/TAMULib/weaver-components/pull/441 can end up getting higher priority due to the dynamically generated ng properties like `_nghost-ysx-c142`.

resolves #361 