### PR TITLE
Revert "Issue 363: While in mobile layout, the tl-header bottom nav item upon click - has border highlighted."

### DIFF
--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.scss
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.scss
@@ -55,10 +55,6 @@
       color: var(--tl-black);
     }
 
-    wvr-nav-list-component .dropdown .wvr-button:focus {
-      box-shadow: none;
-    }
-
     // Weaver Nav List overrides for top navigation
     wvr-nav-list-component[top-navigation-mobile] wvr-nav-li-component,
     wvr-nav-list-component[top-navigation] wvr-nav-li-component,


### PR DESCRIPTION
This reverts #377

There are accessibility concerns with removing this outline.