### PR TITLE
Issue 367: Navigation subsections not expanding in mobile view.

### DIFF
--- a/projects/tl-elements/src/lib/tl-mega-menu/tl-mega-menu-section/tl-mega-menu-section.component.ts
+++ b/projects/tl-elements/src/lib/tl-mega-menu/tl-mega-menu-section/tl-mega-menu-section.component.ts
@@ -32,6 +32,8 @@ export class TlMegaMenuSectionComponent extends TamuAbstractBaseComponent implem
   }
 
   ngOnInit(): void {
+    super.ngOnInit();
+
     const elem = this.eRef.nativeElement as HTMLElement;
     const parentElem = elem.closest('tl-mega-menu');
     if (parentElem) {


### PR DESCRIPTION
The `mobile-layout` class is not appearing on any of the styling.
This results in the CSS not being properly parsed.

This is apparently caused by a lack of a parent `ngOnInit()` being called.