### PR TITLE
Add support for utilizing a local registry for local development.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build:docker": "node scripts/build-docker.js",
     "build:link": "npm run build && node scripts/link-self",
     "build:link-wvr": "node scripts/link-wvr.js",
+    "build:npm-local": "node scripts/npm-local.js",
     "build:static": "npm run build:static-docs && npm run build:static-reports",
     "build:static-setup": "node scripts/build-tl-components-static.js",
     "build:static-docs": "npm run test:audit && npm run build:static-setup && npm run build:docs-setup && npm run build:docs-development && npm run build:docs-usage",

--- a/scripts/npm-local.js
+++ b/scripts/npm-local.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const fs = require('fs-extra');
+const shell = require('shelljs')
+const angularCli = require('@angular/cli');
+const elementsPath = 'dist/tl-elements';
+
+shell.exec('npm --registry http://localhost:4873 install --no-save @wvr/elements');
+
+angularCli.default({
+  cliArgs: ['b'],
+  inputStream: process.stdin,
+  outputStream: process.stdout
+}).then(c => {
+  shell.exit();
+});


### PR DESCRIPTION
Add new command `build:npm-local` to build utilizing the local repository.
This will re-install the wvr dependency using a local registry with the `--no-save` to ensure that the package.json is not updated in the process.

This is the compliment to TAMULib/weaver-components#471.