### PR TITLE
Issue 389: The mobile menu slide out tray continues to allow links to be clicked on when closed.

### DIFF
--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.scss
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.scss
@@ -452,6 +452,7 @@
       .mobile-menu.closed {
         width: 0px;
         opacity: 0;
+        overflow: hidden;
       }
     }
   }


### PR DESCRIPTION
resolves #389

For 1.x versions.