### PR TITLE
Add `npm-local` command to pull in `wvr/elements` without building.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "publish:npm-next": "npm run publish:npm next",
     "lint": "ng lint",
     "ng": "ng",
+    "npm-local": "npm --registry http://localhost:4873 install --no-save @wvr/elements",
     "start": "node ./scripts/build-tl-components-configuration.js defaults-dev-overrides.env && ng serve --port 3000",
     "start:dist": "node ./scripts/build-tl-components-configuration.js defaults-dist-overrides.env && node ./scripts/serve-dist.js",
     "start:static": "node ./scripts/build-tl-components-configuration.js defaults-static-overrides.env && static-server static -p 8082",


### PR DESCRIPTION
The `build:npm-local` work for starting the dev environment but not for the dist.
This is because it doesn't build the bundle
The `build` command will build the bundle that is needed by `run:dist`.
Rather than modifying `build`, just provide another command that can be run as-is without being locked into any specific build process.