### PR TITLE
[Issue 407] Some browsers, mobile menu expand/collapse icons does not appear all the way to the right.

### DIFF
--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.scss
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.scss
@@ -540,8 +540,7 @@
           span[button-content] {
             width: 100%;
             span {
-              display: inline-block;
-              width: 100%;
+              display: block;
             }
           }
         }


### PR DESCRIPTION
Tested in Firefox, Chromium, and Edge.

resolves #407