### PR TITLE
Change tl nav list and weaver nav list to use divs with roles.

### DIFF
--- a/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component.scss
+++ b/projects/tl-elements/src/lib/tl-dropdown-menu/tl-dropdown-menu-section/tl-dropdown-menu-section.component.scss
@@ -21,7 +21,7 @@
 
   wvr-nav-list-component {
     ::ng-deep {
-      ul {
+      [role=list] {
         height: auto;
       }
 

--- a/projects/tl-elements/src/lib/tl-footer/tl-footer.component.scss
+++ b/projects/tl-elements/src/lib/tl-footer/tl-footer.component.scss
@@ -29,7 +29,7 @@
       --footer-height: auto;
       --footer-height: auto;
       wvr-nav-list-component {
-        ul.flex-row {
+        [role="list"].flex-row {
           flex-direction: column !important;
         }
       }

--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.scss
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.scss
@@ -28,28 +28,28 @@
     }
 
     wvr-nav-list-component[top-navigation-mobile]
-      > ul
+      > [role="list"]
       > wvr-nav-li-component
-      > li
+      > [role="listitem"]
       > a,
     wvr-nav-list-component[top-navigation]
-      > ul
+      > [role="list"]
       > wvr-nav-li-component
-      > li
+      > [role="listitem"]
       > a {
       padding: 12px;
       color: var(--tl-white);
     }
 
     wvr-nav-list-component[top-navigation-mobile]
-      > ul
+      > [role="list"]
       > wvr-nav-li-component
-      > li
+      > [role="listitem"]
       > a:hover,
     wvr-nav-list-component[top-navigation]
-      > ul
+      > [role="list"]
       > wvr-nav-li-component
-      > li
+      > [role="listitem"]
       > a:hover {
       color: var(--tl-black);
     }
@@ -329,7 +329,7 @@
         }
       }
 
-      .mobile-menu > div > div > wvr-nav-list-component > wvre-nav-li > li > a {
+      .mobile-menu > div > div > wvr-nav-list-component > wvre-nav-li > [role="listitem"] > a {
         display: flex;
         align-items: center;
         justify-content: flex-start;
@@ -354,13 +354,13 @@
           border-right: none;
         }
 
-        ul {
+        [role="list"] {
           justify-content: space-evenly;
           flex-wrap: nowrap !important;
           flex-direction: column !important;
         }
 
-        li {
+        [role="listitem"] {
           justify-content: left !important;
 
           wvr-dropdown-component,
@@ -484,7 +484,7 @@
     transition: width 0.5s ease-in-out, opacity 0.5s ease-in-out;
 
     div.mobile-menu-content {
-      wvre-nav-li > li.nav-item {
+      wvre-nav-li > [role="listitem"].nav-item {
         a {
           white-space: nowrap;
         }


### PR DESCRIPTION
This is an alternative approach to hoisting out the list.

This has the least breakage when it comes to structural changes and CSS.

This uses roles to ensure accessibility compliance.

Anything depending on this for the nav list should change CSS (or similar) references of `ul` into `[role=list]` and `li` into `[role=listitem]`. Only change the `li` that are within the nav list.

resolves #432 