### PR TITLE
Set body,html height

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -12,6 +12,11 @@
 @import '~@wvr/elements/styles/wvr-elements';
 @import '../projects/tl-elements/src/lib/shared/styles/tl-elements';
 
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
 }


### PR DESCRIPTION
Requires https://github.com/TAMULib/weaver-components/pull/503

Sets body/html to 100% to help push footer to bottom of the page.