### PR TITLE
Update the version to fix dependency conflicts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@angular/animations": "12.2.16",
     "@angular/elements": "12.2.16",
+    "@angular/forms": "12.2.16",
     "@angular/platform-browser-dynamic": "12.2.16",
     "@ng-bootstrap/ng-bootstrap": "10.0.0",
     "@ngrx/effects": "12.5.1",
@@ -113,6 +114,7 @@
     "ts-node": "10.9.1"
   },
   "overrides": {
+    "@angular/compiler": "12.2.16",
     "@angular/core": "12.2.16",
     "@types/eslint": "6.8.1",
     "chokidar": "3.5.3",


### PR DESCRIPTION
`@angular/compiler` is added to the `overrides` because `codelyzer` version 6.0.2 is bringing in `@angular/compiler` 9.0.0 .