### PR TITLE
Use 16-slim rather than lts-slim.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.4] - 12-13-22
+### Resolves
+
+- Docker build must use 16-slim rather than lts-slim.
+
 ## [2.0.4] - 12-09-22
 ### Resolves
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG NPM_REGISTRY=upstream
 ARG NODE_ENV=development
 
 # Node stage.
-FROM node:lts-slim as build
+FROM node:16-slim as build
 ARG USER_ID
 ARG USER_NAME
 ARG SOURCE_DIR

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/TAMULib/tamu-library-components.git"
   },
-  "version": "2.0.4-rc.1",
+  "version": "2.0.4-rc.2",
   "private": false,
   "license": "MIT",
   "engines": {

--- a/projects/tl-elements/package.json
+++ b/projects/tl-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wvr/tl-elements",
-  "version": "2.0.4-rc.1",
+  "version": "2.0.4-rc.2",
   "description": "Collection of angular components for TAMU's Custom Web Component UI",
   "author": "Texas A&M University Libraries",
   "private": false,


### PR DESCRIPTION
Node 16 is what is currently supported.