### PR TITLE
Removed undesired line from dropdown

### DIFF
--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.html
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.html
@@ -169,11 +169,6 @@
             <wvr-text-component value="School Visitors"></wvr-text-component>
           </a>
         </wvre-dropdown-menu-item>
-        <wvre-dropdown-menu-item>
-          <a href="//library.tamu.edu/about/other_patrons">
-            <wvr-text-component value="Other Library Guests (Non-TAMU Affiliates)"></wvr-text-component>
-          </a>
-        </wvre-dropdown-menu-item>
       </template>
     </wvr-dropdown-component>
   </wvr-nav-li-component>


### PR DESCRIPTION
Resolves #461 

This removes an option from the "Information For" dropdown, as defined in issue #461 .