### PR TITLE
Tamu lib staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## [2.0.4] - 09-22-23
 ### Resolves
 
-- Remove the 'Other Library Guests (Non-TAMU Affiliates)' link from tl-header. (#461)
-- Snyk fix: upgrade tinymce from 6.2.0 to 6.3.1
-- Snyk fix: upgrade tslib from 2.4.0 to 2.4.1
+- Remove the 'Other Library Guests (Non-TAMU Affiliates)' link from tl-header. (#462)
+- Snyk fix: upgrade tinymce from 6.2.0 to 6.3.1 (#458)
+- Snyk fix: upgrade tslib from 2.4.0 to 2.4.1 (#460)
 - Docker build must use 16-slim rather than lts-slim.
 - Update the version to fix dependency conflicts. (#452)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 # Changelog
 
-## [2.0.4] - 12-13-22
+## [2.0.4] - 09-22-23
 ### Resolves
 
+- Remove the 'Other Library Guests (Non-TAMU Affiliates)' link from tl-header. (#461)
+- Snyk fix: upgrade tinymce from 6.2.0 to 6.3.1
+- Snyk fix: upgrade tslib from 2.4.0 to 2.4.1
 - Docker build must use 16-slim rather than lts-slim.
-
-## [2.0.4] - 12-09-22
-### Resolves
-
 - Update the version to fix dependency conflicts. (#452)
 
 ## [2.0.3] - 10-12-22

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/TAMULib/tamu-library-components.git"
   },
-  "version": "2.0.4-rc.2",
+  "version": "2.0.4",
   "private": false,
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ng-lazyload-image": "9.1.3",
     "ngx-build-plus": "12.2.0",
     "sockjs-client": "1.6.1",
-    "tinymce": "6.2.0"
+    "tinymce": "6.3.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "12.2.16",

--- a/projects/tl-elements/package.json
+++ b/projects/tl-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wvr/tl-elements",
-  "version": "2.0.4-rc.2",
+  "version": "2.0.4",
   "description": "Collection of angular components for TAMU's Custom Web Component UI",
   "author": "Texas A&M University Libraries",
   "private": false,

--- a/projects/tl-elements/package.json
+++ b/projects/tl-elements/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "tslib": "2.4.0"
+    "tslib": "2.4.1"
   },
   "peerDependencies": {
     "@angular/common": "12.2.16",

--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.html
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.html
@@ -169,11 +169,6 @@
             <wvr-text-component value="School Visitors"></wvr-text-component>
           </a>
         </wvre-dropdown-menu-item>
-        <wvre-dropdown-menu-item>
-          <a href="//library.tamu.edu/about/other_patrons">
-            <wvr-text-component value="Other Library Guests (Non-TAMU Affiliates)"></wvr-text-component>
-          </a>
-        </wvre-dropdown-menu-item>
       </template>
     </wvr-dropdown-component>
   </wvr-nav-li-component>

--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.html
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.html
@@ -211,12 +211,6 @@
         </wvre-dropdown-menu-item>
         <wvre-dropdown-menu-item>
           <tl-icon-component [set]="'bootstrap'" [name]="'arrow-right-circle'"></tl-icon-component>
-          <a href="sms:9792561091" class="helpLink">
-            <wvr-text-component value=" Text us @ 979-256-1091 "></wvr-text-component>
-          </a>
-        </wvre-dropdown-menu-item>
-        <wvre-dropdown-menu-item>
-          <tl-icon-component [set]="'bootstrap'" [name]="'arrow-right-circle'"></tl-icon-component>
           <a href="https://askus.library.tamu.edu/contact/" class="helpLink">
             <wvr-text-component value=" Email us "></wvr-text-component>
           </a>


### PR DESCRIPTION
- Remove the 'Other Library Guests (Non-TAMU Affiliates)' link from tl-header. (#462 )
- Snyk fix: upgrade tinymce from 6.2.0 to 6.3.1 ( #458 )
- Snyk fix: upgrade tslib from 2.4.0 to 2.4.1 (#460 )
- Docker build must use 16-slim rather than lts-slim.
- Update the version to fix dependency conflicts. (#452 )