### PR TITLE
Remove the text us link from the help dropdown menu

### DIFF
--- a/projects/tl-elements/src/lib/tl-header/tl-header.component.html
+++ b/projects/tl-elements/src/lib/tl-header/tl-header.component.html
@@ -216,12 +216,6 @@
         </wvre-dropdown-menu-item>
         <wvre-dropdown-menu-item>
           <tl-icon-component [set]="'bootstrap'" [name]="'arrow-right-circle'"></tl-icon-component>
-          <a href="sms:9792561091" class="helpLink">
-            <wvr-text-component value=" Text us @ 979-256-1091 "></wvr-text-component>
-          </a>
-        </wvre-dropdown-menu-item>
-        <wvre-dropdown-menu-item>
-          <tl-icon-component [set]="'bootstrap'" [name]="'arrow-right-circle'"></tl-icon-component>
           <a href="https://askus.library.tamu.edu/contact/" class="helpLink">
             <wvr-text-component value=" Email us "></wvr-text-component>
           </a>


### PR DESCRIPTION
Resolves #464 